### PR TITLE
Improve tty and fix fmt bugs

### DIFF
--- a/kernel/driver/tty/tty.go
+++ b/kernel/driver/tty/tty.go
@@ -5,6 +5,7 @@ import "io"
 // Tty is implemented by objects that can register themselves as ttys.
 type Tty interface {
 	io.Writer
+	io.ByteWriter
 
 	// Position returns the current cursor position (x, y).
 	Position() (uint16, uint16)

--- a/kernel/driver/tty/vt_test.go
+++ b/kernel/driver/tty/vt_test.go
@@ -44,7 +44,12 @@ func TestWrite(t *testing.T) {
 
 	vt.Clear()
 	vt.SetPosition(0, 1)
-	vt.Write([]byte("12\n3\n4\r56"))
+	vt.Write([]byte("12\n\t3\n4\r567\b8"))
+
+	// Tab spanning rows
+	vt.SetPosition(78, 4)
+	vt.WriteByte('\t')
+	vt.WriteByte('9')
 
 	// Trigger scroll
 	vt.SetPosition(79, 24)
@@ -56,9 +61,22 @@ func TestWrite(t *testing.T) {
 	}{
 		{0, 0, '1'},
 		{1, 0, '2'},
-		{0, 1, '3'},
+		// tabs
+		{0, 1, ' '},
+		{1, 1, ' '},
+		{2, 1, ' '},
+		{3, 1, ' '},
+		{4, 1, '3'},
+		// tab spanning 2 rows
+		{78, 3, ' '},
+		{79, 3, ' '},
+		{0, 4, ' '},
+		{1, 4, ' '},
+		{2, 4, '9'},
+		//
 		{0, 2, '5'},
 		{1, 2, '6'},
+		{2, 2, '8'}, // overwritten by BS
 		{79, 23, '!'},
 	}
 


### PR DESCRIPTION
This PR adds support for TAB/BS characters in the TTY implementation and adds a workaround that prevents the early_fmt code from triggering the Go memory allocator when trying to print long format strings.