### PR TITLE
Use linter and fix linter warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 before_install:
   - go get -t -v ./...
 script:
+  - make lint
   - bash coverage.sh
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -112,3 +112,29 @@ endif
 
 clean:
 	@test -d $(BUILD_DIR) && rm -rf $(BUILD_DIR) || true
+
+lint: lint-check-deps
+	@echo "[gometalinter] linting sources"
+	@gometalinter.v1 \
+		--disable-all \
+		--enable=deadcode \
+		--enable=errcheck \
+		--enable=gosimple \
+		--enable=ineffassign \
+		--enable=misspell \
+		--enable=staticcheck \
+		--enable=vet \
+		--enable=vetshadow \
+		--enable=unconvert \
+		--enable=varcheck \
+		--enable=golint \
+		--deadline 300s \
+		--exclude 'return value not checked' \
+		--exclude 'possible misuse of unsafe.Pointer' \
+		./...
+
+lint-check-deps:
+	@go get -u gopkg.in/alecthomas/gometalinter.v1
+	@gometalinter.v1 --install >/dev/null
+
+test:

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-go test -v -race ./...
-
 echo "" > coverage.txt
 
 for d in $(go list ./... | grep -v vendor); do
-    # Running with -race and -covermode=atomic generates false positives so 
-    # we run the -race bit separately
-    go test -coverprofile=profile.out -covermode=atomic $d
+    go test -race -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt
         rm profile.out

--- a/kernel/driver/tty/vt.go
+++ b/kernel/driver/tty/vt.go
@@ -67,7 +67,7 @@ func (t *Vt) Write(data []byte) (int, error) {
 	return len(data), nil
 }
 
-// Write implements io.ByteWriter.
+// WriteByte implements io.ByteWriter.
 func (t *Vt) WriteByte(b byte) error {
 	switch b {
 	case '\r':

--- a/kernel/hal/hal.go
+++ b/kernel/hal/hal.go
@@ -7,7 +7,9 @@ import (
 )
 
 var (
-	egaConsole     = &console.Ega{}
+	egaConsole = &console.Ega{}
+
+	// ActiveTerminal points to the currently active terminal.
 	ActiveTerminal = &tty.Vt{}
 )
 

--- a/kernel/hal/multiboot/multiboot.go
+++ b/kernel/hal/multiboot/multiboot.go
@@ -4,6 +4,7 @@ import "unsafe"
 
 type tagType uint32
 
+// nolint
 const (
 	tagMbSectionEnd tagType = iota
 	tagBootCmdLine
@@ -100,7 +101,7 @@ const (
 	memUnknown
 )
 
-/// MemoryMapEntry describes a memory region entry, namely its physical address,
+// MemoryMapEntry describes a memory region entry, namely its physical address,
 // its length and its type.
 type MemoryMapEntry struct {
 	// The physical address for this memory region.

--- a/kernel/kmain.go
+++ b/kernel/kmain.go
@@ -26,8 +26,4 @@ func Kmain(multibootInfoPtr uintptr) {
 	hal.InitTerminal()
 	hal.ActiveTerminal.Clear()
 	early.Printf("Starting gopher-os\n")
-
-	// Prevent Kmain from returning
-	for {
-	}
 }


### PR DESCRIPTION
This PR enables gometalinter for the kernel sources. The linter is run via `make lint` and it will run as part of the CI flow for this project