### PR TITLE
Implement bitmap-based physical page allocator

### DIFF
--- a/arch/x86_64/asm/rt0_32.s
+++ b/arch/x86_64/asm/rt0_32.s
@@ -297,10 +297,11 @@ _rt0_enter_long_mode:
 	or eax, 1 << 5
 	mov cr4, eax
 
-	; Now enable long mode by modifying the EFER MSR
+	; Now enable long mode (bit 8) and the no-execute support (bit 11) by 
+	; modifying the EFER MSR
 	mov ecx, 0xc0000080
 	rdmsr	; read msr value to eax
-	or eax, 1 << 8
+	or eax, (1 << 8) | (1<<11)
 	wrmsr
 
 	; Finally enable paging

--- a/kernel/mem/pmm/allocator/bitmap_allocator.go
+++ b/kernel/mem/pmm/allocator/bitmap_allocator.go
@@ -306,11 +306,22 @@ func earlyAllocFrame() (pmm.Frame, *kernel.Error) {
 	return earlyAllocator.AllocFrame()
 }
 
+// sysAllocFrame is a helper that delegates a frame allocation request to the
+// bitmap allocator instance.
+func sysAllocFrame() (pmm.Frame, *kernel.Error) {
+	return FrameAllocator.AllocFrame()
+}
+
 // Init sets up the kernel physical memory allocation sub-system.
 func Init(kernelStart, kernelEnd uintptr) *kernel.Error {
 	earlyAllocator.init(kernelStart, kernelEnd)
 	earlyAllocator.printMemoryMap()
 
 	vmm.SetFrameAllocator(earlyAllocFrame)
-	return FrameAllocator.init()
+	if err := FrameAllocator.init(); err != nil {
+		return err
+	}
+	vmm.SetFrameAllocator(sysAllocFrame)
+
+	return nil
 }

--- a/kernel/mem/pmm/allocator/bitmap_allocator.go
+++ b/kernel/mem/pmm/allocator/bitmap_allocator.go
@@ -1,0 +1,164 @@
+package allocator
+
+import (
+	"reflect"
+	"unsafe"
+
+	"github.com/achilleasa/gopher-os/kernel"
+	"github.com/achilleasa/gopher-os/kernel/hal/multiboot"
+	"github.com/achilleasa/gopher-os/kernel/mem"
+	"github.com/achilleasa/gopher-os/kernel/mem/pmm"
+	"github.com/achilleasa/gopher-os/kernel/mem/vmm"
+)
+
+var (
+	// FrameAllocator is a BitmapAllocator instance that serves as the
+	// primary allocator for reserving pages.
+	FrameAllocator BitmapAllocator
+
+	// The followning functions are used by tests to mock calls to the vmm package
+	// and are automatically inlined by the compiler.
+	reserveRegionFn = vmm.EarlyReserveRegion
+	mapFn           = vmm.Map
+)
+
+type framePool struct {
+	// startFrame is the frame number for the first page in this pool.
+	// each free bitmap entry i corresponds to frame (startFrame + i).
+	startFrame pmm.Frame
+
+	// endFrame tracks the last frame in the pool. The total number of
+	// frames is given by: (endFrame - startFrame) - 1
+	endFrame pmm.Frame
+
+	// freeCount tracks the available pages in this pool. The allocator
+	// can use this field to skip fully allocated pools without the need
+	// to scan the free bitmap.
+	freeCount uint32
+
+	// freeBitmap tracks used/free pages in the pool.
+	freeBitmap    []uint64
+	freeBitmapHdr reflect.SliceHeader
+}
+
+// BitmapAllocator implements a physical frame allocator that tracks frame
+// reservations across the available memory pools using bitmaps.
+type BitmapAllocator struct {
+	// totalPages tracks the total number of pages across all pools.
+	totalPages uint32
+
+	// reservedPages tracks the number of reserved pages across all pools.
+	reservedPages uint32
+
+	pools    []framePool
+	poolsHdr reflect.SliceHeader
+}
+
+// init allocates space for the allocator structures using the early bootmem
+// allocator and flags any allocated pages as reserved.
+func (alloc *BitmapAllocator) init() *kernel.Error {
+	return alloc.setupPoolBitmaps()
+}
+
+// setupPoolBitmaps uses the early allocator and vmm region reservation helper
+// to initialize the list of available pools and their free bitmap slices.
+func (alloc *BitmapAllocator) setupPoolBitmaps() *kernel.Error {
+	var (
+		err                 *kernel.Error
+		sizeofPool          = unsafe.Sizeof(framePool{})
+		pageSizeMinus1      = uint64(mem.PageSize - 1)
+		requiredBitmapBytes mem.Size
+	)
+
+	// Detect available memory regions and calculate their pool bitmap
+	// requirements.
+	multiboot.VisitMemRegions(func(region *multiboot.MemoryMapEntry) bool {
+		if region.Type != multiboot.MemAvailable {
+			return true
+		}
+
+		alloc.poolsHdr.Len++
+		alloc.poolsHdr.Cap++
+
+		// Reported addresses may not be page-aligned; round up to get
+		// the start frame and round down to get the end frame
+		regionStartFrame := pmm.Frame(((region.PhysAddress + pageSizeMinus1) & ^pageSizeMinus1) >> mem.PageShift)
+		regionEndFrame := pmm.Frame(((region.PhysAddress+region.Length) & ^pageSizeMinus1)>>mem.PageShift) - 1
+		pageCount := uint32(regionEndFrame - regionStartFrame)
+		alloc.totalPages += pageCount
+
+		// To represent the free page bitmap we need pageCount bits. Since our
+		// slice uses uint64 for storing the bitmap we need to round up the
+		// required bits so they are a multiple of 64 bits
+		requiredBitmapBytes += mem.Size(((pageCount + 63) &^ 63) >> 3)
+		return true
+	})
+
+	// Reserve enough pages to hold the allocator state
+	requiredBytes := mem.Size(((uint64(uintptr(alloc.poolsHdr.Len)*sizeofPool) + uint64(requiredBitmapBytes)) + pageSizeMinus1) & ^pageSizeMinus1)
+	requiredPages := requiredBytes >> mem.PageShift
+	alloc.poolsHdr.Data, err = reserveRegionFn(requiredBytes)
+	if err != nil {
+		return err
+	}
+
+	for page, index := vmm.PageFromAddress(alloc.poolsHdr.Data), mem.Size(0); index < requiredPages; page, index = page+1, index+1 {
+		nextFrame, err := earlyAllocFrame()
+		if err != nil {
+			return err
+		}
+
+		if err = mapFn(page, nextFrame, vmm.FlagPresent|vmm.FlagRW|vmm.FlagNoExecute); err != nil {
+			return err
+		}
+
+		mem.Memset(page.Address(), 0, mem.PageSize)
+	}
+
+	alloc.pools = *(*[]framePool)(unsafe.Pointer(&alloc.poolsHdr))
+
+	// Run a second pass to initialize the free bitmap slices for all pools
+	bitmapStartAddr := alloc.poolsHdr.Data + uintptr(alloc.poolsHdr.Len)*sizeofPool
+	poolIndex := 0
+	multiboot.VisitMemRegions(func(region *multiboot.MemoryMapEntry) bool {
+		if region.Type != multiboot.MemAvailable {
+			return true
+		}
+
+		regionStartFrame := pmm.Frame(((region.PhysAddress + pageSizeMinus1) & ^pageSizeMinus1) >> mem.PageShift)
+		regionEndFrame := pmm.Frame(((region.PhysAddress+region.Length) & ^pageSizeMinus1)>>mem.PageShift) - 1
+		bitmapBytes := uintptr((((regionEndFrame - regionStartFrame) + 63) &^ 63) >> 3)
+
+		alloc.pools[poolIndex].startFrame = regionStartFrame
+		alloc.pools[poolIndex].endFrame = regionEndFrame
+		alloc.pools[poolIndex].freeCount = uint32(regionEndFrame - regionStartFrame + 1)
+		alloc.pools[poolIndex].freeBitmapHdr.Len = int(bitmapBytes >> 3)
+		alloc.pools[poolIndex].freeBitmapHdr.Cap = alloc.pools[poolIndex].freeBitmapHdr.Len
+		alloc.pools[poolIndex].freeBitmapHdr.Data = bitmapStartAddr
+		alloc.pools[poolIndex].freeBitmap = *(*[]uint64)(unsafe.Pointer(&alloc.pools[poolIndex].freeBitmapHdr))
+
+		bitmapStartAddr += bitmapBytes
+		poolIndex++
+		return true
+	})
+
+	return nil
+}
+
+// earlyAllocFrame is a helper that delegates a frame allocation request to the
+// early allocator instance. This function is passed as an argument to
+// vmm.SetFrameAllocator instead of earlyAllocator.AllocFrame. The latter
+// confuses the compiler's escape analysis into thinking that
+// earlyAllocator.Frame escapes to heap.
+func earlyAllocFrame() (pmm.Frame, *kernel.Error) {
+	return earlyAllocator.AllocFrame()
+}
+
+// Init sets up the kernel physical memory allocation sub-system.
+func Init(kernelStart, kernelEnd uintptr) *kernel.Error {
+	earlyAllocator.init(kernelStart, kernelEnd)
+	earlyAllocator.printMemoryMap()
+
+	vmm.SetFrameAllocator(earlyAllocFrame)
+	return FrameAllocator.init()
+}

--- a/kernel/mem/pmm/allocator/bitmap_allocator_test.go
+++ b/kernel/mem/pmm/allocator/bitmap_allocator_test.go
@@ -338,7 +338,7 @@ func TestBitmapAllocatorAllocAndFreeFrame(t *testing.T) {
 		for expFrame := pool.startFrame; expFrame <= pool.endFrame; expFrame++ {
 			got, err := alloc.AllocFrame()
 			if err != nil {
-				t.Fatalf("[pool %d] unexpected error: %v", err)
+				t.Fatalf("[pool %d] unexpected error: %v", poolIndex, err)
 			}
 
 			if got != expFrame {
@@ -364,7 +364,7 @@ func TestBitmapAllocatorAllocAndFreeFrame(t *testing.T) {
 	for poolIndex, pool := range alloc.pools {
 		for frame := pool.startFrame; frame <= pool.endFrame; frame++ {
 			if err := alloc.FreeFrame(frame); err != nil {
-				t.Fatalf("[pool %d] unexpected error: %v", err)
+				t.Fatalf("[pool %d] unexpected error: %v", poolIndex, err)
 			}
 		}
 
@@ -409,6 +409,11 @@ func TestAllocatorPackageInit(t *testing.T) {
 
 		mockTTY()
 		if err := Init(0x100000, 0x1fa7c8); err != nil {
+			t.Fatal(err)
+		}
+
+		// At this point sysAllocFrame should work
+		if _, err := sysAllocFrame(); err != nil {
 			t.Fatal(err)
 		}
 	})

--- a/kernel/mem/pmm/allocator/bitmap_allocator_test.go
+++ b/kernel/mem/pmm/allocator/bitmap_allocator_test.go
@@ -1,0 +1,183 @@
+package allocator
+
+import (
+	"bytes"
+	"math"
+	"testing"
+	"unsafe"
+
+	"github.com/achilleasa/gopher-os/kernel"
+	"github.com/achilleasa/gopher-os/kernel/hal/multiboot"
+	"github.com/achilleasa/gopher-os/kernel/mem"
+	"github.com/achilleasa/gopher-os/kernel/mem/pmm"
+	"github.com/achilleasa/gopher-os/kernel/mem/vmm"
+)
+
+func TestSetupPoolBitmaps(t *testing.T) {
+	defer func() {
+		mapFn = vmm.Map
+		reserveRegionFn = vmm.EarlyReserveRegion
+	}()
+
+	multiboot.SetInfoPtr(uintptr(unsafe.Pointer(&multibootMemoryMap[0])))
+
+	// The captured multiboot data corresponds to qemu running with 128M RAM.
+	// The allocator will need to reserve 2 pages to store the bitmap data.
+	var (
+		alloc   BitmapAllocator
+		physMem = make([]byte, 2*mem.PageSize)
+	)
+
+	// Init phys mem with junk
+	for i := 0; i < len(physMem); i++ {
+		physMem[i] = 0xf0
+	}
+
+	mapCallCount := 0
+	mapFn = func(page vmm.Page, frame pmm.Frame, flags vmm.PageTableEntryFlag) *kernel.Error {
+		mapCallCount++
+		return nil
+	}
+
+	reserveCallCount := 0
+	reserveRegionFn = func(_ mem.Size) (uintptr, *kernel.Error) {
+		reserveCallCount++
+		return uintptr(unsafe.Pointer(&physMem[0])), nil
+	}
+
+	if err := alloc.setupPoolBitmaps(); err != nil {
+		t.Fatal(err)
+	}
+
+	if exp := 2; mapCallCount != exp {
+		t.Fatalf("expected allocator to call vmm.Map %d times; called %d", exp, mapCallCount)
+	}
+
+	if exp := 1; reserveCallCount != exp {
+		t.Fatalf("expected allocator to call vmm.EarlyReserveRegion %d times; called %d", exp, reserveCallCount)
+	}
+
+	if exp, got := 2, len(alloc.pools); got != exp {
+		t.Fatalf("expected allocator to initialize %d pools; got %d", exp, got)
+	}
+
+	for poolIndex, pool := range alloc.pools {
+		if expFreeCount := uint32(pool.endFrame - pool.startFrame + 1); pool.freeCount != expFreeCount {
+			t.Errorf("[pool %d] expected free count to be %d; got %d", poolIndex, expFreeCount, pool.freeCount)
+		}
+
+		if exp, got := int(math.Ceil(float64(pool.freeCount)/64.0)), len(pool.freeBitmap); got != exp {
+			t.Errorf("[pool %d] expected bitmap len to be %d; got %d", poolIndex, exp, got)
+		}
+
+		for blockIndex, block := range pool.freeBitmap {
+			if block != 0 {
+				t.Errorf("[pool %d] expected bitmap block %d to be cleared; got %d", poolIndex, blockIndex, block)
+			}
+		}
+	}
+}
+
+func TestSetupPoolBitmapsErrors(t *testing.T) {
+	defer func() {
+		mapFn = vmm.Map
+		reserveRegionFn = vmm.EarlyReserveRegion
+	}()
+
+	multiboot.SetInfoPtr(uintptr(unsafe.Pointer(&multibootMemoryMap[0])))
+	var alloc BitmapAllocator
+
+	t.Run("vmm.EarlyReserveRegion returns an error", func(t *testing.T) {
+		expErr := &kernel.Error{Module: "test", Message: "something went wrong"}
+
+		reserveRegionFn = func(_ mem.Size) (uintptr, *kernel.Error) {
+			return 0, expErr
+		}
+
+		if err := alloc.setupPoolBitmaps(); err != expErr {
+			t.Fatalf("expected to get error: %v; got %v", expErr, err)
+		}
+	})
+	t.Run("vmm.Map returns an error", func(t *testing.T) {
+		expErr := &kernel.Error{Module: "test", Message: "something went wrong"}
+
+		reserveRegionFn = func(_ mem.Size) (uintptr, *kernel.Error) {
+			return 0, nil
+		}
+
+		mapFn = func(page vmm.Page, frame pmm.Frame, flags vmm.PageTableEntryFlag) *kernel.Error {
+			return expErr
+		}
+
+		if err := alloc.setupPoolBitmaps(); err != expErr {
+			t.Fatalf("expected to get error: %v; got %v", expErr, err)
+		}
+	})
+
+	t.Run("earlyAllocator returns an error", func(t *testing.T) {
+		emptyInfoData := []byte{
+			0, 0, 0, 0, // size
+			0, 0, 0, 0, // reserved
+			0, 0, 0, 0, // tag with type zero and length zero
+			0, 0, 0, 0,
+		}
+
+		multiboot.SetInfoPtr(uintptr(unsafe.Pointer(&emptyInfoData[0])))
+
+		if err := alloc.setupPoolBitmaps(); err != errBootAllocOutOfMemory {
+			t.Fatalf("expected to get error: %v; got %v", errBootAllocOutOfMemory, err)
+		}
+	})
+}
+
+func TestAllocatorPackageInit(t *testing.T) {
+	defer func() {
+		mapFn = vmm.Map
+		reserveRegionFn = vmm.EarlyReserveRegion
+	}()
+
+	var (
+		physMem = make([]byte, 2*mem.PageSize)
+		fb      = mockTTY()
+		buf     bytes.Buffer
+	)
+	multiboot.SetInfoPtr(uintptr(unsafe.Pointer(&multibootMemoryMap[0])))
+
+	t.Run("success", func(t *testing.T) {
+		mapFn = func(page vmm.Page, frame pmm.Frame, flags vmm.PageTableEntryFlag) *kernel.Error {
+			return nil
+		}
+
+		reserveRegionFn = func(_ mem.Size) (uintptr, *kernel.Error) {
+			return uintptr(unsafe.Pointer(&physMem[0])), nil
+		}
+
+		if err := Init(0x100000, 0x1fa7c8); err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 0; i < len(fb); i += 2 {
+			if fb[i] == 0x0 {
+				continue
+			}
+			buf.WriteByte(fb[i])
+		}
+
+		exp := "[boot_mem_alloc] system memory map:    [0x0000000000 - 0x000009fc00], size:     654336, type: available    [0x000009fc00 - 0x00000a0000], size:       1024, type: reserved    [0x00000f0000 - 0x0000100000], size:      65536, type: reserved    [0x0000100000 - 0x0007fe0000], size:  133038080, type: available    [0x0007fe0000 - 0x0008000000], size:     131072, type: reserved    [0x00fffc0000 - 0x0100000000], size:     262144, type: reserved[boot_mem_alloc] available memory: 130559Kb[boot_mem_alloc] kernel loaded at 0x100000 - 0x1fa7c8[boot_mem_alloc] size: 1025992 bytes, reserved pages: 251"
+		if got := buf.String(); got != exp {
+			t.Fatalf("expected printMemoryMap to generate the following output:\n%q\ngot:\n%q", exp, got)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		expErr := &kernel.Error{Module: "test", Message: "something went wrong"}
+
+		mapFn = func(page vmm.Page, frame pmm.Frame, flags vmm.PageTableEntryFlag) *kernel.Error {
+			return expErr
+		}
+
+		if err := Init(0x100000, 0x1fa7c8); err != expErr {
+			t.Fatalf("expected to get error: %v; got %v", expErr, err)
+		}
+	})
+}

--- a/kernel/mem/pmm/allocator/bootmem.go
+++ b/kernel/mem/pmm/allocator/bootmem.go
@@ -134,10 +134,3 @@ func (alloc *bootMemAllocator) printMemoryMap() {
 		uint64(alloc.kernelEndFrame-alloc.kernelStartFrame+1),
 	)
 }
-
-// Init sets up the kernel physical memory allocation sub-system.
-func Init(kernelStart, kernelEnd uintptr) *kernel.Error {
-	earlyAllocator.init(kernelStart, kernelEnd)
-	earlyAllocator.printMemoryMap()
-	return nil
-}

--- a/kernel/mem/pmm/allocator/bootmem_test.go
+++ b/kernel/mem/pmm/allocator/bootmem_test.go
@@ -1,7 +1,6 @@
 package allocator
 
 import (
-	"bytes"
 	"testing"
 	"unsafe"
 
@@ -91,26 +90,6 @@ func TestBootMemoryAllocator(t *testing.T) {
 		if alloc.allocCount != spec.expAllocCount {
 			t.Errorf("[spec %d] expected allocator to allocate %d frames; allocated %d", specIndex, spec.expAllocCount, alloc.allocCount)
 		}
-	}
-}
-
-func TestAllocatorPackageInit(t *testing.T) {
-	fb := mockTTY()
-	multiboot.SetInfoPtr(uintptr(unsafe.Pointer(&multibootMemoryMap[0])))
-
-	Init(0x100000, 0x1fa7c8)
-
-	var buf bytes.Buffer
-	for i := 0; i < len(fb); i += 2 {
-		if fb[i] == 0x0 {
-			continue
-		}
-		buf.WriteByte(fb[i])
-	}
-
-	exp := "[boot_mem_alloc] system memory map:    [0x0000000000 - 0x000009fc00], size:     654336, type: available    [0x000009fc00 - 0x00000a0000], size:       1024, type: reserved    [0x00000f0000 - 0x0000100000], size:      65536, type: reserved    [0x0000100000 - 0x0007fe0000], size:  133038080, type: available    [0x0007fe0000 - 0x0008000000], size:     131072, type: reserved    [0x00fffc0000 - 0x0100000000], size:     262144, type: reserved[boot_mem_alloc] available memory: 130559Kb[boot_mem_alloc] kernel loaded at 0x100000 - 0x1fa7c8[boot_mem_alloc] size: 1025992 bytes, reserved pages: 251"
-	if got := buf.String(); got != exp {
-		t.Fatalf("expected printMemoryMap to generate the following output:\n%q\ngot:\n%q", exp, got)
 	}
 }
 

--- a/kernel/mem/vmm/addr_space.go
+++ b/kernel/mem/vmm/addr_space.go
@@ -1,0 +1,35 @@
+package vmm
+
+import (
+	"github.com/achilleasa/gopher-os/kernel"
+	"github.com/achilleasa/gopher-os/kernel/mem"
+)
+
+var (
+	// earlyReserveLastUsed tracks the last reserved page address and is
+	// decreased after each allocation request. Initially, it points to
+	// tempMappingAddr which coincides with the end of the kernel address
+	// space.
+	earlyReserveLastUsed = tempMappingAddr
+
+	errEarlyReserveNoSpace = &kernel.Error{Module: "early_reserve", Message: "remaining virtual address space not large enough to satisfy reservation request"}
+)
+
+// EarlyReserveRegion reserves a page-aligned contiguous virtual memory region
+// with the requested size in the kernel address space and returns its virtual
+// address. If size is not a multiple of mem.PageSize it will be automatically
+// rounded up.
+//
+// This function allocates regions starting at the end of the kernel address
+// space. It should only be used during the early stages of kernel initialization.
+func EarlyReserveRegion(size mem.Size) (uintptr, *kernel.Error) {
+	size = (size + (mem.PageSize - 1)) & ^(mem.PageSize - 1)
+
+	// reserving a region of the requested size will cause an underflow
+	if uintptr(size) > earlyReserveLastUsed {
+		return 0, errEarlyReserveNoSpace
+	}
+
+	earlyReserveLastUsed -= uintptr(size)
+	return earlyReserveLastUsed, nil
+}

--- a/kernel/mem/vmm/addr_space_test.go
+++ b/kernel/mem/vmm/addr_space_test.go
@@ -1,0 +1,29 @@
+package vmm
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestEarlyReserveAmd64(t *testing.T) {
+	if runtime.GOARCH != "amd64" {
+		t.Skip("test requires amd64 runtime; skipping")
+	}
+
+	defer func(origLastUsed uintptr) {
+		earlyReserveLastUsed = origLastUsed
+	}(earlyReserveLastUsed)
+
+	earlyReserveLastUsed = 4096
+	next, err := EarlyReserveRegion(42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exp := uintptr(0); next != exp {
+		t.Fatal("expected reservation request to be rounded to nearest page")
+	}
+
+	if _, err = EarlyReserveRegion(1); err != errEarlyReserveNoSpace {
+		t.Fatalf("expected to get errEarlyReserveNoSpace; got %v", err)
+	}
+}

--- a/kernel/mem/vmm/map.go
+++ b/kernel/mem/vmm/map.go
@@ -23,14 +23,11 @@ var (
 	errNoHugePageSupport = &kernel.Error{Module: "vmm", Message: "huge pages are not supported"}
 )
 
-// FrameAllocatorFn is a function that can allocate physical frames.
-type FrameAllocatorFn func() (pmm.Frame, *kernel.Error)
-
 // Map establishes a mapping between a virtual page and a physical memory frame
 // using the currently active page directory table. Calls to Map will use the
 // supplied physical frame allocator to initialize missing page tables at each
 // paging level supported by the MMU.
-func Map(page Page, frame pmm.Frame, flags PageTableEntryFlag, allocFn FrameAllocatorFn) *kernel.Error {
+func Map(page Page, frame pmm.Frame, flags PageTableEntryFlag) *kernel.Error {
 	var err *kernel.Error
 
 	walk(page.Address(), func(pteLevel uint8, pte *pageTableEntry) bool {
@@ -53,7 +50,7 @@ func Map(page Page, frame pmm.Frame, flags PageTableEntryFlag, allocFn FrameAllo
 		// physical frame for it map it and clear its contents.
 		if !pte.HasFlags(FlagPresent) {
 			var newTableFrame pmm.Frame
-			newTableFrame, err = allocFn()
+			newTableFrame, err = frameAllocator()
 			if err != nil {
 				return false
 			}
@@ -78,8 +75,8 @@ func Map(page Page, frame pmm.Frame, flags PageTableEntryFlag, allocFn FrameAllo
 // to a fixed virtual address overwriting any previous mapping. The temporary
 // mapping mechanism is primarily used by the kernel to access and initialize
 // inactive page tables.
-func MapTemporary(frame pmm.Frame, allocFn FrameAllocatorFn) (Page, *kernel.Error) {
-	if err := Map(PageFromAddress(tempMappingAddr), frame, FlagRW, allocFn); err != nil {
+func MapTemporary(frame pmm.Frame) (Page, *kernel.Error) {
+	if err := Map(PageFromAddress(tempMappingAddr), frame, FlagRW); err != nil {
 		return 0, err
 	}
 

--- a/kernel/mem/vmm/pdt.go
+++ b/kernel/mem/vmm/pdt.go
@@ -39,7 +39,7 @@ type PageDirectoryTable struct {
 // Init can:
 //  - call mem.Memset to clear the frame contents
 //  - setup a recursive mapping for the last table entry to the page itself.
-func (pdt *PageDirectoryTable) Init(pdtFrame pmm.Frame, allocFn FrameAllocatorFn) *kernel.Error {
+func (pdt *PageDirectoryTable) Init(pdtFrame pmm.Frame) *kernel.Error {
 	pdt.pdtFrame = pdtFrame
 
 	// Check active PDT physical address. If it matches the input pdt then
@@ -50,7 +50,7 @@ func (pdt *PageDirectoryTable) Init(pdtFrame pmm.Frame, allocFn FrameAllocatorFn
 	}
 
 	// Create a temporary mapping for the pdt frame so we can work on it
-	pdtPage, err := mapTemporaryFn(pdtFrame, allocFn)
+	pdtPage, err := mapTemporaryFn(pdtFrame)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (pdt *PageDirectoryTable) Init(pdtFrame pmm.Frame, allocFn FrameAllocatorFn
 // function with the difference that it also supports inactive page PDTs by
 // establishing a temporary mapping so that Map() can access the inactive PDT
 // entries.
-func (pdt PageDirectoryTable) Map(page Page, frame pmm.Frame, flags PageTableEntryFlag, allocFn FrameAllocatorFn) *kernel.Error {
+func (pdt PageDirectoryTable) Map(page Page, frame pmm.Frame, flags PageTableEntryFlag) *kernel.Error {
 	var (
 		activePdtFrame   = pmm.Frame(activePDTFn() >> mem.PageShift)
 		lastPdtEntryAddr uintptr
@@ -89,7 +89,7 @@ func (pdt PageDirectoryTable) Map(page Page, frame pmm.Frame, flags PageTableEnt
 		flushTLBEntryFn(lastPdtEntryAddr)
 	}
 
-	err := mapFn(page, frame, flags, allocFn)
+	err := mapFn(page, frame, flags)
 
 	if activePdtFrame != pdt.pdtFrame {
 		lastPdtEntry.SetFrame(activePdtFrame)

--- a/kernel/mem/vmm/pdt_test.go
+++ b/kernel/mem/vmm/pdt_test.go
@@ -15,7 +15,7 @@ func TestPageDirectoryTableInitAmd64(t *testing.T) {
 		t.Skip("test requires amd64 runtime; skipping")
 	}
 
-	defer func(origFlushTLBEntry func(uintptr), origActivePDT func() uintptr, origMapTemporary func(pmm.Frame, FrameAllocatorFn) (Page, *kernel.Error), origUnmap func(Page) *kernel.Error) {
+	defer func(origFlushTLBEntry func(uintptr), origActivePDT func() uintptr, origMapTemporary func(pmm.Frame) (Page, *kernel.Error), origUnmap func(Page) *kernel.Error) {
 		flushTLBEntryFn = origFlushTLBEntry
 		activePDTFn = origActivePDT
 		mapTemporaryFn = origMapTemporary
@@ -32,7 +32,7 @@ func TestPageDirectoryTableInitAmd64(t *testing.T) {
 			return pdtFrame.Address()
 		}
 
-		mapTemporaryFn = func(_ pmm.Frame, _ FrameAllocatorFn) (Page, *kernel.Error) {
+		mapTemporaryFn = func(_ pmm.Frame) (Page, *kernel.Error) {
 			t.Fatal("unexpected call to MapTemporary")
 			return 0, nil
 		}
@@ -42,7 +42,7 @@ func TestPageDirectoryTableInitAmd64(t *testing.T) {
 			return nil
 		}
 
-		if err := pdt.Init(pdtFrame, nil); err != nil {
+		if err := pdt.Init(pdtFrame); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -61,7 +61,7 @@ func TestPageDirectoryTableInitAmd64(t *testing.T) {
 			return 0
 		}
 
-		mapTemporaryFn = func(_ pmm.Frame, _ FrameAllocatorFn) (Page, *kernel.Error) {
+		mapTemporaryFn = func(_ pmm.Frame) (Page, *kernel.Error) {
 			return PageFromAddress(uintptr(unsafe.Pointer(&physPage[0]))), nil
 		}
 
@@ -73,7 +73,7 @@ func TestPageDirectoryTableInitAmd64(t *testing.T) {
 			return nil
 		}
 
-		if err := pdt.Init(pdtFrame, nil); err != nil {
+		if err := pdt.Init(pdtFrame); err != nil {
 			t.Fatal(err)
 		}
 
@@ -110,7 +110,7 @@ func TestPageDirectoryTableInitAmd64(t *testing.T) {
 
 		expErr := &kernel.Error{Module: "test", Message: "error mapping page"}
 
-		mapTemporaryFn = func(_ pmm.Frame, _ FrameAllocatorFn) (Page, *kernel.Error) {
+		mapTemporaryFn = func(_ pmm.Frame) (Page, *kernel.Error) {
 			return 0, expErr
 		}
 
@@ -119,7 +119,7 @@ func TestPageDirectoryTableInitAmd64(t *testing.T) {
 			return nil
 		}
 
-		if err := pdt.Init(pdtFrame, nil); err != expErr {
+		if err := pdt.Init(pdtFrame); err != expErr {
 			t.Fatalf("expected to get error: %v; got %v", *expErr, err)
 		}
 	})
@@ -130,7 +130,7 @@ func TestPageDirectoryTableMapAmd64(t *testing.T) {
 		t.Skip("test requires amd64 runtime; skipping")
 	}
 
-	defer func(origFlushTLBEntry func(uintptr), origActivePDT func() uintptr, origMap func(Page, pmm.Frame, PageTableEntryFlag, FrameAllocatorFn) *kernel.Error) {
+	defer func(origFlushTLBEntry func(uintptr), origActivePDT func() uintptr, origMap func(Page, pmm.Frame, PageTableEntryFlag) *kernel.Error) {
 		flushTLBEntryFn = origFlushTLBEntry
 		activePDTFn = origActivePDT
 		mapFn = origMap
@@ -147,7 +147,7 @@ func TestPageDirectoryTableMapAmd64(t *testing.T) {
 			return pdtFrame.Address()
 		}
 
-		mapFn = func(_ Page, _ pmm.Frame, _ PageTableEntryFlag, _ FrameAllocatorFn) *kernel.Error {
+		mapFn = func(_ Page, _ pmm.Frame, _ PageTableEntryFlag) *kernel.Error {
 			return nil
 		}
 
@@ -156,7 +156,7 @@ func TestPageDirectoryTableMapAmd64(t *testing.T) {
 			flushCallCount++
 		}
 
-		if err := pdt.Map(page, pmm.Frame(321), FlagRW, nil); err != nil {
+		if err := pdt.Map(page, pmm.Frame(321), FlagRW); err != nil {
 			t.Fatal(err)
 		}
 
@@ -182,7 +182,7 @@ func TestPageDirectoryTableMapAmd64(t *testing.T) {
 			return activePdtFrame.Address()
 		}
 
-		mapFn = func(_ Page, _ pmm.Frame, _ PageTableEntryFlag, _ FrameAllocatorFn) *kernel.Error {
+		mapFn = func(_ Page, _ pmm.Frame, _ PageTableEntryFlag) *kernel.Error {
 			return nil
 		}
 
@@ -205,7 +205,7 @@ func TestPageDirectoryTableMapAmd64(t *testing.T) {
 			flushCallCount++
 		}
 
-		if err := pdt.Map(page, pmm.Frame(321), FlagRW, nil); err != nil {
+		if err := pdt.Map(page, pmm.Frame(321), FlagRW); err != nil {
 			t.Fatal(err)
 		}
 

--- a/kernel/mem/vmm/vmm.go
+++ b/kernel/mem/vmm/vmm.go
@@ -1,0 +1,17 @@
+package vmm
+
+import (
+	"github.com/achilleasa/gopher-os/kernel"
+	"github.com/achilleasa/gopher-os/kernel/mem/pmm"
+)
+
+var frameAllocator FrameAllocatorFn
+
+// FrameAllocatorFn is a function that can allocate physical frames.
+type FrameAllocatorFn func() (pmm.Frame, *kernel.Error)
+
+// SetFrameAllocator registers a frame allocator function that will be used by
+// the vmm code when new physical frames need to be allocated.
+func SetFrameAllocator(allocFn FrameAllocatorFn) {
+	frameAllocator = allocFn
+}


### PR DESCRIPTION
This PR implements a bitmap based physical page allocator that supports both frame allocation and deallocation requests. The new allocator depends on the functionality provided by the early bootmem allocator (#24) to bootstrap its internal state. Once the allocator is fully bootstrapped it migrates all existing reservations from the early allocator and also flags the frames used by the kernel as reserved. 

The bitmap-based allocator allocates and initializes a free frame pool for each available memory region with size >= 1 page. Each frame pool uses a bitmap (a []uint64) to track frame reservations for the pool frames. Each pool also includes a free frame counter which allows the allocator to skip fully allocated pools without the need to examine the free page bitmap. The use of uint64 for holding the bitmap data allows the allocator to efficiently skip over 64-page blocks if they are already allocated (all bits in the block set to 1). Once a free block is located, then a bit scan is required to find a free slot and reserve it.

To allocate memory for storing the pools and bitmap data, the allocator first visits the memory regions reported by the bootloader and calculates the space required for the bitmap and the pool structure (sizeof(framePool)). The required space is rounded up to the nearest page multiple and the required pages are reserved using the bootmem allocator. 

Since paging is enabled, the physical frames returned by the bootmem allocator need to be mapped to the kernel's virtual address space so they can be accessed by the bitmap allocator. This is achieved using `vmm.EarlyReserveRegion` helper that reserves a contiguous virtual address block at the end of the kernel's address space and by mapping all physical frames to it using `vmm.Map`.