### PR TITLE
Implement copy on write pages

### DIFF
--- a/arch/x86_64/asm/rt0_32.s
+++ b/arch/x86_64/asm/rt0_32.s
@@ -304,9 +304,9 @@ _rt0_enter_long_mode:
 	or eax, (1 << 8) | (1<<11)
 	wrmsr
 
-	; Finally enable paging
+	; Finally enable paging (bit 31) and user/kernel page write protection (bit 16)
 	mov eax, cr0
-	or eax, 1 << 31
+	or eax, (1 << 31) | (1<<16)
 	mov cr0, eax
 
 	; We are in 32-bit compatibility submode. We need to load a 64bit GDT 

--- a/kernel/mem/mem.go
+++ b/kernel/mem/mem.go
@@ -27,3 +27,23 @@ func Memset(addr uintptr, value byte, size Size) {
 		copy(target[index:], target[:index])
 	}
 }
+
+// Memcopy copies size bytes from src to dst.
+func Memcopy(src, dst uintptr, size Size) {
+	if size == 0 {
+		return
+	}
+
+	srcSlice := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Len:  int(size),
+		Cap:  int(size),
+		Data: src,
+	}))
+	dstSlice := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Len:  int(size),
+		Cap:  int(size),
+		Data: dst,
+	}))
+
+	copy(dstSlice, srcSlice)
+}

--- a/kernel/mem/mem_test.go
+++ b/kernel/mem/mem_test.go
@@ -25,3 +25,28 @@ func TestMemset(t *testing.T) {
 		}
 	}
 }
+
+func TestMemcopy(t *testing.T) {
+	// memcopy with a 0 size should be a no-op
+	Memcopy(uintptr(0), uintptr(0), 0)
+
+	var (
+		src = make([]byte, PageSize)
+		dst = make([]byte, PageSize)
+	)
+	for i := 0; i < len(src); i++ {
+		src[i] = byte(i % 256)
+	}
+
+	Memcopy(
+		uintptr(unsafe.Pointer(&src[0])),
+		uintptr(unsafe.Pointer(&dst[0])),
+		PageSize,
+	)
+
+	for i := 0; i < len(src); i++ {
+		if got := dst[i]; got != src[i] {
+			t.Errorf("value mismatch between src and dst at index %d", i)
+		}
+	}
+}

--- a/kernel/mem/vmm/constants_amd64.go
+++ b/kernel/mem/vmm/constants_amd64.go
@@ -80,6 +80,10 @@ const (
 	// for this page when the swapping page tables by updating the CR3 register.
 	FlagGlobal
 
+	// FlagCopyOnWrite is used to implement copy-on-write functionality. This
+	// flag and FlagRW are mutually exclusive.
+	FlagCopyOnWrite = 1 << 9
+
 	// FlagNoExecute if set, indicates that a page contains non-executable code.
 	FlagNoExecute = 1 << 63
 )

--- a/kernel/mem/vmm/map.go
+++ b/kernel/mem/vmm/map.go
@@ -37,7 +37,7 @@ func Map(page Page, frame pmm.Frame, flags PageTableEntryFlag) *kernel.Error {
 		if pteLevel == pageLevels-1 {
 			*pte = 0
 			pte.SetFrame(frame)
-			pte.SetFlags(FlagPresent | flags)
+			pte.SetFlags(flags)
 			flushTLBEntryFn(page.Address())
 			return true
 		}
@@ -77,7 +77,7 @@ func Map(page Page, frame pmm.Frame, flags PageTableEntryFlag) *kernel.Error {
 // mapping mechanism is primarily used by the kernel to access and initialize
 // inactive page tables.
 func MapTemporary(frame pmm.Frame) (Page, *kernel.Error) {
-	if err := Map(PageFromAddress(tempMappingAddr), frame, FlagRW); err != nil {
+	if err := Map(PageFromAddress(tempMappingAddr), frame, FlagPresent|FlagRW); err != nil {
 		return 0, err
 	}
 

--- a/kernel/mem/vmm/map_test.go
+++ b/kernel/mem/vmm/map_test.go
@@ -144,6 +144,24 @@ func TestMapTemporaryErrorsAmd64(t *testing.T) {
 			t.Fatalf("got unexpected error %v", err)
 		}
 	})
+
+	t.Run("map BlankReservedFrame RW", func(t *testing.T) {
+		defer func() { protectReservedZeroedPage = false }()
+
+		protectReservedZeroedPage = true
+		if err := Map(Page(0), ReservedZeroedFrame, FlagRW); err != errAttemptToRWMapReservedFrame {
+			t.Fatalf("expected errAttemptToRWMapReservedFrame; got: %v", err)
+		}
+	})
+
+	t.Run("temp-map BlankReservedFrame RW", func(t *testing.T) {
+		defer func() { protectReservedZeroedPage = false }()
+
+		protectReservedZeroedPage = true
+		if _, err := MapTemporary(ReservedZeroedFrame); err != errAttemptToRWMapReservedFrame {
+			t.Fatalf("expected errAttemptToRWMapReservedFrame; got: %v", err)
+		}
+	})
 }
 
 func TestUnmapAmd64(t *testing.T) {


### PR DESCRIPTION
This PR extends the page fault exception handler from #29 to support copy-on-writes. To enable copy-on-write semantics when mapping a virtual page to a physical frame (via `vmm.Map`) the following combination of flags need to be specified: `FlagPresent | FlagCopyOnWrite`. Omitting `FlagRW` from the list of flags ensures that this page is mapped as **read-only**. 

Any write attempt on a read-only page will cause a page fault. The page fault exception handler will notice that the virtual page corresponding to the fault address is mapped with `FlagCopyOnWrite` and will recover from the page fault by taking the following steps:
- allocate a new physical frame and establish a temporary mapping for it so it can be accessed
- copy the original physical frame contents to the new frame
- update the page entry for the page to point to the new frame and change its flags to `FlagPresent | FlagRW`
- resume execution from the point where the fault occurred

Any **other** type of page fault will be considered non-recoverable and the kernel will panic. Copy-on-write page semantics can be used to implement:
- fork-like functionality
- lazy/on-demand memory allocation

---

To implement a fork, the kernel needs to make a copy of the process page directory while flagging all mapped pages while changing their flags to: `FlagPresent | FlagCopyOnWrite`. The forked process can still read the original process data but any attempt to write to a page will trigger a new allocation and copy of the original page. 

Here is a short example:
```golang
func ForkPage() {
	frame, err := allocator.FrameAllocator.AllocFrame()
	if err != nil {
		kernel.Panic(err)
	}

	page1 := vmm.PageFromAddress(0xbadf00d000)
	page2 := vmm.PageFromAddress(0xfeedf000)

	// Map page1 as RW
	if err = vmm.Map(page1, frame, vmm.FlagPresent|vmm.FlagRW); err != nil {
		kernel.Panic(err)
	}

	// Map page2 as RO + CopyOnWrite
	if err = vmm.Map(page2, frame, vmm.FlagPresent|vmm.FlagCopyOnWrite); err != nil {
		kernel.Panic(err)
	}

	ptrToPage1 := (*uint64)(unsafe.Pointer(page1.Address()))
	ptrToPage2 := (*uint64)(unsafe.Pointer(page2.Address()))

        // Reading from page2 returns the page1 data
	*ptrToPage1 = 0xc0ffee
	early.Printf("*ptrToPage1: 0x%x, *ptrToPage2: 0x%x\n", *ptrToPage1, *ptrToPage2)

	// Writing to page2 causes a fault and a new frame allocation
	*ptrToPage2 = 0xdeadc0de
	early.Printf("*ptrToPage1: 0x%x, *ptrToPage2: 0x%x\n", *ptrToPage1, *ptrToPage2)
}
```

---

Lazy/on-demand memory allocation allows the kernel to reserve a virtual page region that may exceed the amount of available physical memory without making any initial physical frame reservations. 

The vmm package's `Init()` function reserves a physical frame which is then temporarily mapped and its contents cleared to 0. This frame is exported as `vmm.ReservedZeroedFrame`. Any attempt to map a page to this special frame  (via `vmm.Map` or `vmm.MapTemporary`) with `FlagRW` will fail with an error.

To enable lazy/on-demand memory allocation, the kernel can then map `vmm.ReservedZeroedFrame` to multiple virtual pages using  `FlagPresent | FlagCopyOnWrite`. All initial reads from those virtual pages are served from the same zeroed frame. Writes however will trigger a page fault and actual physical frame allocations.

Here is an example for this case:
```golang
func ReserveOnDemand(start vmm.Page, pageCount int) *kernel.Error {
  var err *kernel.Error
  mapFlags := vmm.FlagPresent|vmm.FlagCopyOnWrite
  for page := start; pageCount > 0; pageCount, page = pageCount-1, page+1 {
     if err = vmm.Map(page, vmm.ReservedZeroedFrame, mapFlags); err != nil {
       return err
     }
  }
  return nil
}
```
