### PR TITLE
Trampoline-based runtime call redirects

### DIFF
--- a/arch/x86_64/script/linker.ld.in
+++ b/arch/x86_64/script/linker.ld.in
@@ -38,6 +38,15 @@ SECTIONS {
 		*(COMMON)
 		*(.bss)
 	}
+
+	/* Go function redirection table. This table is used for hooking 
+	 * Go runtime function symbols so that calls to them are redirected to
+	 * functions provided by the kernel.
+	 */ 
+	.goredirectstbl ALIGN(4K): AT(ADDR(.goredirectstbl) - PAGE_OFFSET)
+	{
+		*(.goredirectstbl)
+	}
 	
 	_kernel_end = ALIGN(4K);
 }

--- a/kernel/kmain/kmain.go
+++ b/kernel/kmain/kmain.go
@@ -8,6 +8,10 @@ import (
 	"github.com/achilleasa/gopher-os/kernel/mem/vmm"
 )
 
+var (
+	errKmainReturned = &kernel.Error{Module: "kmain", Message: "Kmain returned"}
+)
+
 // Kmain is the only Go symbol that is visible (exported) from the rt0 initialization
 // code. This function is invoked by the rt0 assembly code after setting up the GDT
 // and setting up a a minimal g0 struct that allows Go code using the 4K stack
@@ -27,8 +31,12 @@ func Kmain(multibootInfoPtr, kernelStart, kernelEnd uintptr) {
 
 	var err *kernel.Error
 	if err = allocator.Init(kernelStart, kernelEnd); err != nil {
-		kernel.Panic(err)
+		panic(err)
 	} else if err = vmm.Init(); err != nil {
-		kernel.Panic(err)
+		panic(err)
 	}
+
+	// Use kernel.Panic instead of panic to prevent the compiler from
+	// treating kernel.Panic as dead-code and eliminating it.
+	kernel.Panic(errKmainReturned)
 }

--- a/kernel/panic.go
+++ b/kernel/panic.go
@@ -8,11 +8,28 @@ import (
 var (
 	// cpuHaltFn is mocked by tests and is automatically inlined by the compiler.
 	cpuHaltFn = cpu.Halt
+
+	errRuntimePanic = &Error{Module: "rt", Message: "unknown cause"}
 )
 
 // Panic outputs the supplied error (if not nil) to the console and halts the
-// CPU. Calls to Panic never return.
-func Panic(err *Error) {
+// CPU. Calls to Panic never return. Panic also works as a redirection target
+// for calls to panic() (resolved via runtime.gopanic)
+//go:redirect-from runtime.gopanic
+func Panic(e interface{}) {
+	var err *Error
+
+	switch t := e.(type) {
+	case *Error:
+		err = t
+	case string:
+		errRuntimePanic.Message = t
+		err = errRuntimePanic
+	case error:
+		errRuntimePanic.Message = t.Error()
+		err = errRuntimePanic
+	}
+
 	early.Printf("\n-----------------------------------\n")
 	if err != nil {
 		early.Printf("[%s] unrecoverable error: %s\n", err.Module, err.Message)

--- a/tools/redirects/redirects.go
+++ b/tools/redirects/redirects.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"debug/elf"
+	"encoding/binary"
+	"errors"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type redirect struct {
+	src string
+	dst string
+
+	srcVMA uint64
+	dstVMA uint64
+}
+
+func exit(err error) {
+	fmt.Fprintf(os.Stderr, "[redirects] error: %s\n", err.Error())
+	os.Exit(1)
+}
+
+func pkgPrefix() (string, error) {
+	goPath := os.Getenv("GOPATH") + "/src/"
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimPrefix(cwd, goPath), nil
+}
+
+func collectGoFiles(root string) ([]string, error) {
+	var goFiles []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return err
+		}
+
+		if filepath.Ext(path) == ".go" && !strings.Contains(path, "_test") {
+			goFiles = append(goFiles, path)
+		}
+
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return goFiles, nil
+}
+
+func findRedirects(goFiles []string) ([]*redirect, error) {
+	var redirects []*redirect
+
+	prefix, err := pkgPrefix()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, goFile := range goFiles {
+		fset := token.NewFileSet()
+
+		f, err := parser.ParseFile(fset, goFile, nil, parser.ParseComments)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %s", goFile, err)
+		}
+
+		cmap := ast.NewCommentMap(fset, f, f.Comments)
+		cmap.Filter(f)
+		for astNode, commentGroups := range cmap {
+			fnDecl, ok := astNode.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+
+			for _, commentGroup := range commentGroups {
+				for _, comment := range commentGroup.List {
+					if !strings.Contains(comment.Text, "go:redirect-from") {
+						continue
+					}
+
+					// build qualified name to fn
+					fqName := fmt.Sprintf("%s/%s.%s",
+						prefix,
+						goFile[:strings.LastIndexByte(goFile, '/')],
+						fnDecl.Name,
+					)
+
+					fields := strings.Fields(comment.Text)
+					if len(fields) != 2 || fields[0] != "//go:redirect-from" {
+						return nil, fmt.Errorf("malformed go:redirect-from syntax for %q", fqName)
+					}
+
+					redirects = append(redirects, &redirect{
+						src: fields[1],
+						dst: fqName,
+					})
+				}
+			}
+		}
+	}
+
+	return redirects, nil
+}
+
+func elfRedirectTableOffset(imgFile string) (uint64, error) {
+	f, err := elf.Open(imgFile)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	redirectsSection := f.Section(".goredirectstbl")
+	if redirectsSection == nil {
+		return 0, fmt.Errorf("%s: missing .goredirectstbl section", imgFile)
+	}
+
+	return redirectsSection.Offset, nil
+}
+
+func elfWriteRedirectTable(redirects []*redirect, imgFile string) error {
+	redirectTableOffset, err := elfRedirectTableOffset(imgFile)
+	if err != nil {
+		return err
+	}
+
+	// Open kernel image file and seek to table offset
+	f, err := os.OpenFile(imgFile, os.O_WRONLY, os.ModeType)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err = f.Seek(int64(redirectTableOffset), io.SeekStart); err != nil {
+		return err
+	}
+
+	for _, redirect := range redirects {
+		binary.Write(f, binary.LittleEndian, redirect.srcVMA)
+		binary.Write(f, binary.LittleEndian, redirect.dstVMA)
+	}
+
+	return nil
+}
+
+func elfResolveRedirectSymbols(redirects []*redirect, imgFile string) error {
+	f, err := elf.Open(imgFile)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	symbols, err := f.Symbols()
+	if err != nil {
+		return err
+	}
+
+	for _, redirect := range redirects {
+		for _, symbol := range symbols {
+			if symbol.Name == redirect.src {
+				redirect.srcVMA = symbol.Value
+			}
+			if symbol.Name == redirect.dst {
+				redirect.dstVMA = symbol.Value
+			}
+		}
+
+		switch {
+		case redirect.srcVMA == 0:
+			return fmt.Errorf("%s: could not locate address of %q", imgFile, redirect.src)
+		case redirect.dstVMA == 0:
+			return fmt.Errorf("%s: could not locate address of %q", imgFile, redirect.dst)
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	if matches, _ := filepath.Glob("kernel/"); len(matches) != 1 {
+		exit(errors.New("this tool must be run from the kernel root folder"))
+	}
+
+	if len(flag.Args()) == 0 {
+		exit(errors.New("missing command"))
+	}
+
+	cmd := flag.Arg(0)
+	var imgFile string
+	switch cmd {
+	case "count":
+	case "populate-table":
+		if len(flag.Args()) != 2 {
+			exit(errors.New("populate-table requires the path to the kernel image as an argument"))
+		}
+		imgFile = flag.Arg(1)
+	default:
+		exit(fmt.Errorf("unknown command %q", cmd))
+	}
+
+	goFiles, err := collectGoFiles("kernel/")
+	if err != nil {
+		exit(err)
+	}
+
+	redirects, err := findRedirects(goFiles)
+	if err != nil {
+		exit(err)
+	}
+
+	if cmd == "count" {
+		fmt.Printf("%d", len(redirects))
+		return
+	}
+
+	if err = elfResolveRedirectSymbols(redirects, imgFile); err != nil {
+		exit(err)
+	}
+
+	if err = elfWriteRedirectTable(redirects, imgFile); err != nil {
+		exit(err)
+	}
+}


### PR DESCRIPTION
This PR introduces a new mechanism for hijacking calls to any Go function and redirecting them to another function. As a proof-of concept, the last commit in this PR redirects calls to `panic` (`runtime.gopanic`) to `kernel.Panic`. This mechanism will be used in future PRs to bootstrap the Go memory allocator.

---

To apply a function redirection, a special directive (`go:redirect-from`) needs to be specified together with the function declaration that serves as the redirect target. Here is an example:

```golang
//go:redirect-from runtime.gopanic
func foo(_ interface{}){
	...
}
```

The `go:redirect-from` directive specifies that calls to `runtime.gopanic` will be redirected to`foo`. The implementation of this redirect is a bit complicated but a build tool (implemented in https://github.com/achilleasa/gopher-os/commit/de124d2ad68656bbb2803e840aed9a0a291fb7a2) helps automate this:

the `redirects` tool implements 2 commands:
- `count`: find all redirection directives in `kernel` and its sub-packages and output their count
- `populate-table`: given the kernel image file, this command resolves for each redirect all (src, dst) symbols' virtual addresses and writes their addresses into the `.goredirectstbl` section which is pre-allocated by the rt0 code.

---

The rt0 code defines the `_rt0_redirect_table` which contains enough space for `2 x NUM_REDIRECTS` pointers (8-bytes each). `NUM_REDIRECTS` is a define which is set by the Makefile to the output of the `redirects` tool `count` command before invoking nasm.

A post-link step in the Makefile invokes the `redirects` tool with the `populate-table` command which now resolves the symbols and writes their addresses to the `rt0_redirect_table`. The table itself is defined in its own dedicated section (`.goredirectstbl`) which allows the `redirects` tool to easily find its offset in the ELF file (section offset == rt0_redirect_table offset).

The rt0 code iterates the `rt0_redirect_table` (in _rt0_install_redirect_trampolines) and for each entry sets up a trampoline for the `destination` symbol (redirect target) and **copies** it onto the `source` symbol. This hack (modifying code in the `.text` section) works because memory protection is not yet activated. The trampoline exploits rip-relative addressing to avoid dirtying any registers; it uses 14 bytes and is implemented with the following asm snippet:

```asm 
jmp [rip+0]
dq abs_address_to_jump_to
```

After installing the trampolines, any call to the `source` symbol gets automatically redirected by jumping to the `destination` symbol