### PR TITLE
Use latest Go in Vagrantfile and improve debugging

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     apt-get update
     apt-get install -y nasm gccgo xorriso
-    [ ! -d "/usr/local/go" ] && wget -qO- https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz | tar xz -C /usr/local
+    [ ! -d "/usr/local/go" ] && wget -qO- https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz | tar xz -C /usr/local
     echo "export GOROOT=/usr/local/go" > /etc/profile.d/go.sh
     echo "export GOBIN=/usr/local/go/bin" >> /etc/profile.d/go.sh
     echo "export GOPATH=/home/vagrant/workspace" >> /etc/profile.d/go.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     apt-get update
-    apt-get install -y nasm gccgo xorriso
+    apt-get install -y nasm make xorriso
     [ ! -d "/usr/local/go" ] && wget -qO- https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz | tar xz -C /usr/local
     echo "export GOROOT=/usr/local/go" > /etc/profile.d/go.sh
     echo "export GOBIN=/usr/local/go/bin" >> /etc/profile.d/go.sh


### PR DESCRIPTION
This PR updates the Vagrantfile to use the latest 1.8 Go version (1.8.3 at the time of this PR) and improves debugging support by:
- disabling optimizations and inlining when building gdb target
- loading Go runtime GDB helpers (`$GOROOT/src/runtime/runtime-gdb.py`)
- switching to split mode when running the debugger