### PR TITLE
Enable support for interfaces and the map primitive

### DIFF
--- a/kernel/goruntime/bootstrap_test.go
+++ b/kernel/goruntime/bootstrap_test.go
@@ -1,6 +1,7 @@
 package goruntime
 
 import (
+	"reflect"
 	"testing"
 	"unsafe"
 
@@ -236,11 +237,32 @@ func TestSysAlloc(t *testing.T) {
 	})
 }
 
+func TestGetRandomData(t *testing.T) {
+	sample1 := make([]byte, 128)
+	sample2 := make([]byte, 128)
+
+	getRandomData(sample1)
+	getRandomData(sample2)
+
+	if reflect.DeepEqual(sample1, sample2) {
+		t.Fatal("expected getRandomData to return different values for each invocation")
+	}
+}
+
 func TestInit(t *testing.T) {
 	defer func() {
 		mallocInitFn = mallocInit
+		algInitFn = algInit
+		modulesInitFn = modulesInit
+		typeLinksInitFn = typeLinksInit
+		itabsInitFn = itabsInit
 	}()
+
 	mallocInitFn = func() {}
+	algInitFn = func() {}
+	modulesInitFn = func() {}
+	typeLinksInitFn = func() {}
+	itabsInitFn = func() {}
 
 	if err := Init(); err != nil {
 		t.Fatal(t)


### PR DESCRIPTION
This PR enables support for Go interfaces and the map primitive.  

To initialize the hash algorithm for the map primitive, the runtime calls `runtime.getRandomData` which reads data off `/dev/random`. As this is not available inside the kernel, the code in this PR redirects this call to a kernel function that uses a PRNG.
