### PR TITLE
Map vga text console framebuffer

### DIFF
--- a/src/gopheros/device/video/console/probe.go
+++ b/src/gopheros/device/video/console/probe.go
@@ -1,9 +1,15 @@
 package console
 
-import "gopheros/device"
-import "gopheros/kernel/hal/multiboot"
+import (
+	"gopheros/device"
+	"gopheros/kernel/cpu"
+	"gopheros/kernel/hal/multiboot"
+	"gopheros/kernel/mem/vmm"
+)
 
 var (
+	mapRegionFn          = vmm.MapRegion
+	portWriteByteFn      = cpu.PortWriteByte
 	getFramebufferInfoFn = multiboot.GetFramebufferInfo
 
 	// ProbeFuncs is a slice of device probe functions that is used by


### PR DESCRIPTION
Currently, the kernel can write to 0xb80000 because this is part of the initial identify mapping set up by the rt0 code. When we establish new mappings for the kernel using its real VMA address then writes to the framebuffer will cause a page fault unless we explicitly map it when initializing the driver.