### PR TITLE
Setup granular PDT for kernel

### DIFF
--- a/src/arch/x86_64/asm/rt0_32.s
+++ b/src/arch/x86_64/asm/rt0_32.s
@@ -355,6 +355,20 @@ write_string:
 ;------------------------------------------------------------------------------
 bits 64 
 _rt0_64_entry_trampoline:
+	; The currently loaded GDT points to the physical address of gdt0. This
+	; works for now since we identity map the first 8M of the kernel. When
+	; we set up a proper PDT for the VMA address of the kernel, the 0-8M
+	; mapping will be invalid causing a page fault when the CPU tries to
+	; restore the segment registers while returning from the page fault
+	; handler.
+	;
+	; To fix this, we need to update the GDT so it uses the 48-bit virtual 
+	; address of gdt0.
+	mov rax, gdt0_desc
+	mov rbx, gdt0
+	mov qword [rax+2], rbx
+	lgdt [rax]
+
 	mov rsp, stack_top     ; now that paging is enabled we can load the stack 
 			       ; with the virtual address of the allocated stack.
 	

--- a/src/arch/x86_64/asm/rt0_64.s
+++ b/src/arch/x86_64/asm/rt0_64.s
@@ -51,6 +51,8 @@ _rt0_64_entry:
 	extern _kernel_end
 	extern kernel.Kmain
 	
+	mov rax, PAGE_OFFSET
+	push rax
 	mov rax, _kernel_end - PAGE_OFFSET
 	push rax
 	mov rax, _kernel_start - PAGE_OFFSET

--- a/src/gopheros/kernel/cpu/cpu_amd64.s
+++ b/src/gopheros/kernel/cpu/cpu_amd64.s
@@ -19,7 +19,8 @@ TEXT ·FlushTLBEntry(SB),NOSPLIT,$0
 
 TEXT ·SwitchPDT(SB),NOSPLIT,$0
 	// loading CR3 also triggers a TLB flush
-	MOVQ pdtPhysAddr+0(FP), CR3
+	MOVQ pdtPhysAddr+0(FP), AX
+	MOVQ AX, CR3
 	RET
 
 TEXT ·ActivePDT(SB),NOSPLIT,$0

--- a/src/gopheros/kernel/kmain/kmain.go
+++ b/src/gopheros/kernel/kmain/kmain.go
@@ -33,6 +33,7 @@ func Kmain(multibootInfoPtr, kernelStart, kernelEnd, kernelPageOffset uintptr) {
 	var err *kernel.Error
 	if err = allocator.Init(kernelStart, kernelEnd); err != nil {
 		panic(err)
+	} else if err = vmm.Init(kernelPageOffset); err != nil {
 		panic(err)
 	} else if err = goruntime.Init(); err != nil {
 		panic(err)

--- a/src/gopheros/kernel/kmain/kmain.go
+++ b/src/gopheros/kernel/kmain/kmain.go
@@ -20,18 +20,19 @@ var (
 // allocated by the assembly code.
 //
 // The rt0 code passes the address of the multiboot info payload provided by the
-// bootloader as well as the physical addresses for the kernel start/end.
+// bootloader as well as the physical addresses for the kernel start/end. In
+// addition, the start of the kernel virtual address space is passed to the
+// kernelPageOffset argument.
 //
 // Kmain is not expected to return. If it does, the rt0 code will halt the CPU.
 //
 //go:noinline
-func Kmain(multibootInfoPtr, kernelStart, kernelEnd uintptr) {
+func Kmain(multibootInfoPtr, kernelStart, kernelEnd, kernelPageOffset uintptr) {
 	multiboot.SetInfoPtr(multibootInfoPtr)
 
 	var err *kernel.Error
 	if err = allocator.Init(kernelStart, kernelEnd); err != nil {
 		panic(err)
-	} else if err = vmm.Init(); err != nil {
 		panic(err)
 	} else if err = goruntime.Init(); err != nil {
 		panic(err)

--- a/src/gopheros/stub.go
+++ b/src/gopheros/stub.go
@@ -11,5 +11,5 @@ var multibootInfoPtr uintptr
 // A global variable is passed as an argument to Kmain to prevent the compiler
 // from inlining the actual call and removing Kmain from the generated .o file.
 func main() {
-	kmain.Kmain(multibootInfoPtr, 0, 0)
+	kmain.Kmain(multibootInfoPtr, 0, 0, 0)
 }


### PR DESCRIPTION
This PR uses the kernel ELF section information provided by the multiboot package to set up a granular page directory table (PDT) and switches to it (https://github.com/achilleasa/gopher-os/commit/6195f3fc3b2a7ea8fe60ff55ed2355a9da59bdb2). Up to the point where the kernel switches to the new PDT, it uses a simpler PDT that contains the following identity mappings (defined as 2MB pages):

|physical address  range | virtual address range |
|---------|--------|
|0 to 8M   | 0 to 8 M |
|0 to 8M   | PAGE_OFFSET to PAGE_OFFSET + 8M| 

Where PAGE_OFFSET is the start of the kernel virtual address space defined by `arch/XXX/asm/constants.inc`. For 64-bit kernels this is set to the 48-bit canonical memory address `0xffff800000000000`. The linker script sets the `physical load address` for the kernel to `1M` and configures the kernel virtual start address to `PAGE_OFFSET + 1M`.

The new PDT uses page granularity (4K) and also uses the appropriate flags (e.g NX, RW) depending on the ELF section contents. For example:
- .text gets mapped read-only
- .data gets mapped RW and the no-execute (NX) bit is set 
- .rodata uses just the NX bit

Setting up the new PDT must happen when the `vmm` system initializes and **before** the Go memory allocator is initialized. This ensures that in addition to the ELF section contents we can properly account for any additional pages mapped by the bitmap memory allocator. If we were to establish the new PDT after bootstrapping the Go allocator we would have to scan through ~500GB of virtual address space to locate the pages that were mapped by it (through calls to runtime.sysMap).

One caveat to performing the PDT initialization before initializing the Go allocator is that the code in the multiboot package that returns the ELF sections must be refactored so at it doesn't perform any allocations. This is achieved by converting the existing `GetElfSections` implementation into a visitor-based implementation (https://github.com/achilleasa/gopher-os/commit/a2d58f894944b40c8448c6c591aa20196c1bd025)

