### PR TITLE
Enable support for defer

### DIFF
--- a/src/arch/x86_64/asm/rt0_64.s
+++ b/src/arch/x86_64/asm/rt0_64.s
@@ -95,6 +95,7 @@ _rt0_64_setup_go_runtime_structs:
 	; Link m0 to the g0
 	extern runtime.m0
 	mov rbx, runtime.m0
+	mov qword [rbx+GO_M_CURG], rsi     ; m.curg = g0
 	mov qword [rbx+GO_M_G0], rsi       ; m.g0 = g0
 	mov qword [rsi+GO_G_M], rbx        ; g.m = m
 

--- a/src/gopheros/kernel/goruntime/bootstrap_test.go
+++ b/src/gopheros/kernel/goruntime/bootstrap_test.go
@@ -267,6 +267,7 @@ func TestInit(t *testing.T) {
 		typeLinksInitFn = typeLinksInit
 		itabsInitFn = itabsInit
 		initGoPackagesFn = initGoPackages
+		procResizeFn = procResize
 	}()
 
 	mallocInitFn = func() {}
@@ -275,7 +276,7 @@ func TestInit(t *testing.T) {
 	typeLinksInitFn = func() {}
 	itabsInitFn = func() {}
 	initGoPackagesFn = func() {}
-
+	procResizeFn = func(_ int32) uintptr { return 0 }
 	if err := Init(); err != nil {
 		t.Fatal(t)
 	}

--- a/src/gopheros/kernel/kmain/kmain.go
+++ b/src/gopheros/kernel/kmain/kmain.go
@@ -39,10 +39,13 @@ func Kmain(multibootInfoPtr, kernelStart, kernelEnd, kernelPageOffset uintptr) {
 		panic(err)
 	}
 
+	// After goruntime.Init returns we can safely use defer
+	defer func() {
+		// Use kfmt.Panic instead of panic to prevent the compiler from
+		// treating kernel.Panic as dead-code and eliminating it.
+		kfmt.Panic(errKmainReturned)
+	}()
+
 	// Detect and initialize hardware
 	hal.DetectHardware()
-
-	// Use kfmt.Panic instead of panic to prevent the compiler from
-	// treating kernel.Panic as dead-code and eliminating it.
-	kfmt.Panic(errKmainReturned)
 }


### PR DESCRIPTION
This PR tweaks the runtime bootstrap code so the kernel code can use `defer`.