### PR TITLE
Add Makefile target for running gopher-os ISO using vbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ OS = $(shell uname -s)
 ARCH := x86_64
 BUILD_DIR := build
 BUILD_ABS_DIR := $(CURDIR)/$(BUILD_DIR)
+VBOX_VM_NAME := gopher-os
 
 kernel_target :=$(BUILD_DIR)/kernel-$(ARCH).bin
 iso_target := $(BUILD_DIR)/kernel-$(ARCH).iso
@@ -129,10 +130,17 @@ iso:
 
 endif
 
-run: GC_FLAGS += -B
-run: iso
+run-qemu: GC_FLAGS += -B
+run-qemu: iso
 	qemu-system-$(ARCH) -cdrom $(iso_target) -vga std -d int,cpu_reset -no-reboot
 
+run-vbox: iso
+	VBoxManage createvm --name $(VBOX_VM_NAME) --ostype "Linux_64" --register || true
+	VBoxManage storagectl $(VBOX_VM_NAME) --name "IDE Controller" --add ide || true
+	VBoxManage storageattach $(VBOX_VM_NAME) --storagectl "IDE Controller" --port 0 --device 0 --type dvddrive \
+		--medium $(iso_target) || true
+	VBoxManage startvm $(VBOX_VM_NAME)
+	
 # When building gdb target disable optimizations (-N) and inlining (l) of Go code
 gdb: GC_FLAGS += -N -l
 gdb: iso


### PR DESCRIPTION
This PR updates the Makefile to include targets for booting the kernel ISO using either qemu (`make run-qemu`) or Virtualbox (`make run-vbox`).