### PR TITLE
Map EGA color indices to correct DAC entries for VGA HW

### DIFF
--- a/src/gopheros/device/video/console/vga_text.go
+++ b/src/gopheros/device/video/console/vga_text.go
@@ -14,6 +14,13 @@ import (
 	"unsafe"
 )
 
+// egaColorIndexToDACEntry is a LUT that maps an EGA color index to the DAC
+// entry used by the VGA hardware when looking up the color.
+var egaColorIndexToDACEntry = []uint8{
+	0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x14, 0x07, 0x38, 0x39, 0x3a, 0x3b,
+	0x3c, 0x3d, 0x3e, 0x3f,
+}
+
 // VgaTextConsole implements an EGA-compatible 80x25 text console using VGA
 // mode 0x3. The console supports the default 16 EGA colors which can be
 // overridden using the SetPaletteColor method.
@@ -183,7 +190,7 @@ func (cons *VgaTextConsole) SetPaletteColor(index uint8, rgba color.RGBA) {
 	// Load palette entry to the DAC. In this mode, colors are specified
 	// using 6-bits for each component; the RGB values need to be converted
 	// to the 0-63 range.
-	portWriteByteFn(0x3c8, index)
+	portWriteByteFn(0x3c8, egaColorIndexToDACEntry[index])
 	portWriteByteFn(0x3c9, rgba.R>>2)
 	portWriteByteFn(0x3c9, rgba.G>>2)
 	portWriteByteFn(0x3c9, rgba.B>>2)

--- a/src/gopheros/device/video/console/vga_text_test.go
+++ b/src/gopheros/device/video/console/vga_text_test.go
@@ -286,7 +286,7 @@ func TestVgaTextSetPaletteColor(t *testing.T) {
 			val  uint8
 		}{
 			// Values will be normalized in the 0-31 range
-			{0x3c8, 1},
+			{0x3c8, 0x3f},
 			{0x3c9, 63},
 			{0x3c9, 31},
 			{0x3c9, 0},
@@ -303,9 +303,9 @@ func TestVgaTextSetPaletteColor(t *testing.T) {
 		}
 
 		rgba := color.RGBA{R: 255, G: 127, B: 0}
-		cons.SetPaletteColor(1, rgba)
+		cons.SetPaletteColor(15, rgba)
 
-		if got := cons.Palette()[1]; got != rgba {
+		if got := cons.Palette()[15]; got != rgba {
 			t.Errorf("expected color at index 1 to be:\n%v\ngot:\n%v", rgba, got)
 		}
 


### PR DESCRIPTION
Most HW out there (including the emulated variants offered by qemu/virtualbox) uses the EGA color index to select a 6-bit value which is then used to index the VGA palette. 

While the first 6 colors use the same EGA and VGA DAC indices, the other colors use **non-sequential** indices. This PR changes the `SetPaletteColor` implementation in the vga_text driver to use a LUT to map the palette index ti the correct DAC entry.